### PR TITLE
Add WebSocket JWT authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# Clinic Management System
+
+This project provides a simple clinic management backend built with Spring Boot.  
+
+## WebSocket authentication
+
+WebSocket connections to `/ws` require a valid JWT. A custom
+`JwtHandshakeInterceptor` extracts the `Authorization` header during the initial
+handshake and creates a `UserPrincipleAuthenticationToken`. If the token is
+missing or invalid the handshake is rejected with a `401` status.
+
+A `JwtChannelInterceptor` performs the same validation for STOMP `CONNECT`
+frames ensuring messages only arrive from authenticated users.
+
+Clients must include an `Authorization: Bearer <token>` header when opening the
+WebSocket connection or sending the STOMP `CONNECT` frame.

--- a/src/main/java/com/example/DocLib/configruation/WebSocketConfiguration.java
+++ b/src/main/java/com/example/DocLib/configruation/WebSocketConfiguration.java
@@ -1,16 +1,24 @@
 package com.example.DocLib.configruation;
 
-import org.springframework.boot.autoconfigure.websocket.servlet.WebSocketMessagingAutoConfiguration;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 
-import java.net.http.WebSocket;
+import com.example.DocLib.security.JwtChannelInterceptor;
+import com.example.DocLib.security.JwtDecoder;
+import com.example.DocLib.security.JwtHandshakeInterceptor;
+import com.example.DocLib.security.JwtPrincipleConverter;
+
 @Configuration
 @EnableWebSocketMessageBroker
+@RequiredArgsConstructor
 public class WebSocketConfiguration implements WebSocketMessageBrokerConfigurer {
+    private final JwtDecoder jwtDecoder;
+    private final JwtPrincipleConverter jwtPrincipleConverter;
     @Override
     public void configureMessageBroker(MessageBrokerRegistry config) {
         config.enableSimpleBroker("/queue", "/topic");
@@ -20,8 +28,14 @@ public class WebSocketConfiguration implements WebSocketMessageBrokerConfigurer 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("ws")
+                .addInterceptors(new JwtHandshakeInterceptor(jwtDecoder, jwtPrincipleConverter))
                 .setAllowedOrigins("http://127.0.0.1:5500")
                 .withSockJS();
+    }
+
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        registration.interceptors(new JwtChannelInterceptor(jwtDecoder, jwtPrincipleConverter));
     }
 
 

--- a/src/main/java/com/example/DocLib/security/JwtChannelInterceptor.java
+++ b/src/main/java/com/example/DocLib/security/JwtChannelInterceptor.java
@@ -1,0 +1,41 @@
+package com.example.DocLib.security;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.util.StringUtils;
+
+@RequiredArgsConstructor
+public class JwtChannelInterceptor implements ChannelInterceptor {
+    private final JwtDecoder jwtDecoder;
+    private final JwtPrincipleConverter jwtPrincipleConverter;
+
+    @Override
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+        if (accessor != null && StompCommand.CONNECT.equals(accessor.getCommand())) {
+            String auth = accessor.getFirstNativeHeader("Authorization");
+            if (StringUtils.hasText(auth) && auth.startsWith("Bearer ")) {
+                String token = auth.substring(7);
+                try {
+                    var jwt = jwtDecoder.decode(token);
+                    if ("access".equals(jwt.getClaim("type").asString())) {
+                        var principal = jwtPrincipleConverter.convert(jwt);
+                        var authentication = new UserPrincipleAuthenticationToken(principal);
+                        accessor.setUser(authentication);
+                        return message;
+                    }
+                } catch (Exception ignored) {
+                    // ignore invalid token
+                }
+            }
+            // Reject connection if token is missing or invalid
+            return null;
+        }
+        return message;
+    }
+}

--- a/src/main/java/com/example/DocLib/security/JwtHandshakeInterceptor.java
+++ b/src/main/java/com/example/DocLib/security/JwtHandshakeInterceptor.java
@@ -1,0 +1,52 @@
+package com.example.DocLib.security;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.util.StringUtils;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.server.HandshakeInterceptor;
+
+import java.util.Map;
+
+@RequiredArgsConstructor
+public class JwtHandshakeInterceptor implements HandshakeInterceptor {
+    private final JwtDecoder jwtDecoder;
+    private final JwtPrincipleConverter jwtPrincipleConverter;
+
+    @Override
+    public boolean beforeHandshake(ServerHttpRequest request,
+                                   ServerHttpResponse response,
+                                   WebSocketHandler wsHandler,
+                                   Map<String, Object> attributes) {
+        String authHeader = request.getHeaders().getFirst("Authorization");
+        if (StringUtils.hasText(authHeader) && authHeader.startsWith("Bearer ")) {
+            String token = authHeader.substring(7);
+            try {
+                var jwt = jwtDecoder.decode(token);
+                if ("access".equals(jwt.getClaim("type").asString())) {
+                    var principal = jwtPrincipleConverter.convert(jwt);
+                    var authentication = new UserPrincipleAuthenticationToken(principal);
+                    attributes.put("principal", authentication);
+                    return true;
+                }
+            } catch (Exception ignored) {
+                // ignore invalid token
+            }
+        }
+
+        // reject handshake if no valid token
+        if (response instanceof org.springframework.http.server.ServletServerHttpResponse httpResponse) {
+            httpResponse.getServletResponse().setStatus(401);
+        }
+        return false;
+    }
+
+    @Override
+    public void afterHandshake(ServerHttpRequest request,
+                               ServerHttpResponse response,
+                               WebSocketHandler wsHandler,
+                               Exception exception) {
+        // no-op
+    }
+}

--- a/src/test/java/com/example/DocLib/security/JwtHandshakeInterceptorTest.java
+++ b/src/test/java/com/example/DocLib/security/JwtHandshakeInterceptorTest.java
@@ -1,0 +1,63 @@
+package com.example.DocLib.security;
+
+import com.auth0.jwt.interfaces.DecodedJWT;
+import com.example.DocLib.configruation.UserPrincipleConfig;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.http.server.ServletServerHttpRequest;
+import org.springframework.http.server.ServletServerHttpResponse;
+
+import java.util.Collections;
+import java.util.HashMap;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class JwtHandshakeInterceptorTest {
+    @Test
+    void beforeHandshakeSetsPrincipalAttribute() {
+        JwtDecoder decoder = mock(JwtDecoder.class);
+        JwtPrincipleConverter converter = mock(JwtPrincipleConverter.class);
+        DecodedJWT jwt = mock(DecodedJWT.class);
+
+        when(decoder.decode("token")).thenReturn(jwt);
+        when(jwt.getClaim("type").asString()).thenReturn("access");
+        UserPrincipleConfig cfg = UserPrincipleConfig.builder()
+                .userId(1L)
+                .username("test")
+                .authorities(Collections.emptyList())
+                .password(null)
+                .userRepository(null)
+                .build();
+        when(converter.convert(jwt)).thenReturn(cfg);
+
+        JwtHandshakeInterceptor interceptor = new JwtHandshakeInterceptor(decoder, converter);
+        MockHttpServletRequest servletRequest = new MockHttpServletRequest();
+        servletRequest.addHeader("Authorization", "Bearer token");
+        ServletServerHttpRequest request = new ServletServerHttpRequest(servletRequest);
+        ServletServerHttpResponse response = new ServletServerHttpResponse(new MockHttpServletResponse());
+        HashMap<String, Object> attributes = new HashMap<>();
+
+        boolean result = interceptor.beforeHandshake(request, response, null, attributes);
+        assertTrue(result);
+        assertTrue(attributes.get("principal") instanceof UserPrincipleAuthenticationToken);
+    }
+
+    @Test
+    void handshakeRejectedWithoutToken() {
+        JwtDecoder decoder = mock(JwtDecoder.class);
+        JwtPrincipleConverter converter = mock(JwtPrincipleConverter.class);
+
+        JwtHandshakeInterceptor interceptor = new JwtHandshakeInterceptor(decoder, converter);
+        MockHttpServletRequest servletRequest = new MockHttpServletRequest();
+        ServletServerHttpRequest request = new ServletServerHttpRequest(servletRequest);
+        MockHttpServletResponse servletResponse = new MockHttpServletResponse();
+        ServletServerHttpResponse response = new ServletServerHttpResponse(servletResponse);
+        HashMap<String, Object> attributes = new HashMap<>();
+
+        boolean result = interceptor.beforeHandshake(request, response, null, attributes);
+        assertFalse(result);
+        assertEquals(401, servletResponse.getStatus());
+    }
+}


### PR DESCRIPTION
## Summary
- add README with WebSocket authentication details
- implement `JwtHandshakeInterceptor` and `JwtChannelInterceptor`
- configure WebSocket to use new interceptors
- add unit test for handshake interceptor

## Testing
- `./mvnw -q test` *(failed: wget: Failed to fetch https://repo.maven.apache.org/...)*

------
https://chatgpt.com/codex/tasks/task_e_684af5e1642c8331be24bcb6643da83e