### PR TITLE
Add unit tests for JWT security components

### DIFF
--- a/src/test/java/com/example/DocLib/security/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/example/DocLib/security/JwtAuthenticationFilterTest.java
@@ -1,0 +1,49 @@
+package com.example.DocLib.security;
+
+import com.auth0.jwt.interfaces.DecodedJWT;
+import com.example.DocLib.configruation.UserPrincipleConfig;
+import jakarta.servlet.FilterChain;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class JwtAuthenticationFilterTest {
+    @AfterEach
+    void clearContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void doFilterInternalSetsAuthentication() throws Exception {
+        JwtDecoder decoder = mock(JwtDecoder.class);
+        JwtPrincipleConverter converter = mock(JwtPrincipleConverter.class);
+        DecodedJWT jwt = mock(DecodedJWT.class);
+        when(decoder.decode("token")).thenReturn(jwt);
+        when(jwt.getClaim("type").asString()).thenReturn("access");
+        UserPrincipleConfig cfg = UserPrincipleConfig.builder()
+                .userId(2L)
+                .username("user")
+                .authorities(Collections.emptyList())
+                .build();
+        when(converter.convert(jwt)).thenReturn(cfg);
+
+        JwtAuthenticationFilter filter = new JwtAuthenticationFilter(decoder, converter);
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Authorization", "Bearer token");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain chain = mock(FilterChain.class);
+
+        filter.doFilterInternal(request, response, chain);
+
+        assertNotNull(SecurityContextHolder.getContext().getAuthentication());
+        assertTrue(SecurityContextHolder.getContext().getAuthentication() instanceof UserPrincipleAuthenticationToken);
+        verify(chain).doFilter(request, response);
+    }
+}

--- a/src/test/java/com/example/DocLib/security/JwtChannelInterceptorTest.java
+++ b/src/test/java/com/example/DocLib/security/JwtChannelInterceptorTest.java
@@ -1,0 +1,44 @@
+package com.example.DocLib.security;
+
+import com.auth0.jwt.interfaces.DecodedJWT;
+import com.example.DocLib.configruation.UserPrincipleConfig;
+import org.junit.jupiter.api.Test;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class JwtChannelInterceptorTest {
+    @Test
+    void preSendSetsUserOnValidToken() {
+        JwtDecoder decoder = mock(JwtDecoder.class);
+        JwtPrincipleConverter converter = mock(JwtPrincipleConverter.class);
+        DecodedJWT jwt = mock(DecodedJWT.class);
+        when(decoder.decode("token")).thenReturn(jwt);
+        when(jwt.getClaim("type").asString()).thenReturn("access");
+        UserPrincipleConfig cfg = UserPrincipleConfig.builder()
+                .userId(10L)
+                .username("u")
+                .authorities(Collections.emptyList())
+                .build();
+        when(converter.convert(jwt)).thenReturn(cfg);
+
+        JwtChannelInterceptor interceptor = new JwtChannelInterceptor(decoder, converter);
+
+        StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.CONNECT);
+        accessor.addNativeHeader("Authorization", "Bearer token");
+        Message<byte[]> message = MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
+
+        Message<?> result = interceptor.preSend(message, mock(MessageChannel.class));
+        StompHeaderAccessor resultAccessor = StompHeaderAccessor.wrap(result);
+        assertNotNull(resultAccessor.getUser());
+        assertTrue(resultAccessor.getUser() instanceof UserPrincipleAuthenticationToken);
+    }
+}

--- a/src/test/java/com/example/DocLib/security/JwtDecoderTest.java
+++ b/src/test/java/com/example/DocLib/security/JwtDecoderTest.java
@@ -1,0 +1,24 @@
+package com.example.DocLib.security;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class JwtDecoderTest {
+    @Test
+    void decodeValidToken() {
+        JwtProperties props = new JwtProperties();
+        props.setSecretKey("secret");
+        String token = JWT.create()
+                .withSubject("42")
+                .withClaim("type", "access")
+                .sign(Algorithm.HMAC256("secret"));
+
+        JwtDecoder decoder = new JwtDecoder(props);
+        var decoded = decoder.decode(token);
+        assertEquals("42", decoded.getSubject());
+        assertEquals("access", decoded.getClaim("type").asString());
+    }
+}

--- a/src/test/java/com/example/DocLib/security/JwtIssuerTest.java
+++ b/src/test/java/com/example/DocLib/security/JwtIssuerTest.java
@@ -1,0 +1,44 @@
+package com.example.DocLib.security;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class JwtIssuerTest {
+    @Test
+    void issueAccessTokenContainsExpectedClaims() {
+        JwtProperties props = new JwtProperties();
+        props.setSecretKey("secret");
+        JwtIssuer issuer = new JwtIssuer(props);
+
+        String token = issuer.issueAccessToken(1L, "user", List.of("USER"));
+        var decoded = JWT.require(Algorithm.HMAC256("secret"))
+                .build()
+                .verify(token);
+
+        assertEquals("1", decoded.getSubject());
+        assertEquals("user", decoded.getClaim("u").asString());
+        assertEquals(List.of("ROLE_USER"), decoded.getClaim("r").asList(String.class));
+        assertEquals("access", decoded.getClaim("type").asString());
+    }
+
+    @Test
+    void issueRefreshTokenContainsTypeRefresh() {
+        JwtProperties props = new JwtProperties();
+        props.setSecretKey("secret");
+        JwtIssuer issuer = new JwtIssuer(props);
+
+        String token = issuer.issueRefreshToken(5L, "user");
+        var decoded = JWT.require(Algorithm.HMAC256("secret"))
+                .build()
+                .verify(token);
+
+        assertEquals("5", decoded.getSubject());
+        assertEquals("user", decoded.getClaim("u").asString());
+        assertEquals("refresh", decoded.getClaim("type").asString());
+    }
+}

--- a/src/test/java/com/example/DocLib/security/JwtPrincipleConverterTest.java
+++ b/src/test/java/com/example/DocLib/security/JwtPrincipleConverterTest.java
@@ -1,0 +1,28 @@
+package com.example.DocLib.security;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class JwtPrincipleConverterTest {
+    @Test
+    void convertAddsRolePrefix() {
+        String token = JWT.create()
+                .withSubject("3")
+                .withClaim("u", "alice")
+                .withClaim("r", java.util.List.of("ADMIN"))
+                .sign(Algorithm.HMAC256("secret"));
+        DecodedJWT jwt = JWT.decode(token);
+
+        JwtPrincipleConverter converter = new JwtPrincipleConverter();
+        var principal = converter.convert(jwt);
+
+        assertEquals(3L, principal.getUserId());
+        assertEquals("alice", principal.getUsername());
+        assertEquals(1, principal.getAuthorities().size());
+        assertEquals("ROLE_ADMIN", principal.getAuthorities().get(0).getAuthority());
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests covering JwtIssuer and JwtDecoder
- add unit tests for JwtChannelInterceptor and JwtAuthenticationFilter
- add tests for JwtPrincipleConverter

## Testing
- `mvn test` *(fails: wget failed to fetch Maven)*

------
https://chatgpt.com/codex/tasks/task_e_684aff87c8088331b9ecfdc352efe9a8