### PR TITLE
Add unit tests for service layer

### DIFF
--- a/src/test/java/com/example/DocLib/controllers/AppointmentControllerTest.java
+++ b/src/test/java/com/example/DocLib/controllers/AppointmentControllerTest.java
@@ -1,0 +1,63 @@
+package com.example.DocLib.controllers;
+
+import com.example.DocLib.configruation.UserPrincipleConfig;
+import com.example.DocLib.dto.appointment.AppointmentDto;
+import com.example.DocLib.security.UserPrincipleAuthenticationToken;
+import com.example.DocLib.services.implementation.AppointmentServicesImp;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class AppointmentControllerTest {
+
+    @AfterEach
+    void clearContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    private void setAuth(Long id, String role) {
+        UserPrincipleConfig cfg = UserPrincipleConfig.builder()
+                .userId(id)
+                .username("u")
+                .authorities(Collections.singleton(() -> role))
+                .build();
+        SecurityContextHolder.getContext()
+                .setAuthentication(new UserPrincipleAuthenticationToken(cfg));
+    }
+
+    @Test
+    void getAppointmentByIdReturnsFromService() {
+        AppointmentServicesImp service = mock(AppointmentServicesImp.class);
+        AppointmentController controller = new AppointmentController(service);
+        setAuth(1L, "ROLE_PATIENT");
+
+        AppointmentDto dto = new AppointmentDto();
+        when(service.getAppointmentById(5L)).thenReturn(dto);
+
+        ResponseEntity<AppointmentDto> result = controller.getAppointmentById(1L,5L);
+
+        assertSame(dto, result.getBody());
+        verify(service).getAppointmentById(5L);
+    }
+
+    @Test
+    void cancelAppointmentByDoctorUsesService() {
+        AppointmentServicesImp service = mock(AppointmentServicesImp.class);
+        AppointmentController controller = new AppointmentController(service);
+        setAuth(2L, "ROLE_DOCTOR");
+
+        AppointmentDto dto = new AppointmentDto();
+        when(service.cancelAppointmentByClinic(3L, "r")).thenReturn(dto);
+
+        ResponseEntity<AppointmentDto> result = controller.cancelAppointmentByDoctor(3L, "r", 2L);
+
+        assertSame(dto, result.getBody());
+        verify(service).cancelAppointmentByClinic(3L, "r");
+    }
+}

--- a/src/test/java/com/example/DocLib/controllers/AuthControllerTest.java
+++ b/src/test/java/com/example/DocLib/controllers/AuthControllerTest.java
@@ -1,0 +1,50 @@
+package com.example.DocLib.controllers;
+
+import com.example.DocLib.dto.UserDto;
+import com.example.DocLib.models.authentication.LoginRequest;
+import com.example.DocLib.models.authentication.TokenResponse;
+import com.example.DocLib.services.implementation.AuthServices;
+import com.example.DocLib.services.implementation.UserServicesImp;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class AuthControllerTest {
+    @Test
+    void registerDelegatesToService() {
+        UserServicesImp userServices = mock(UserServicesImp.class);
+        AuthServices authServices = mock(AuthServices.class);
+        PasswordEncoder encoder = mock(PasswordEncoder.class);
+        AuthController controller = new AuthController(userServices, authServices, encoder);
+
+        UserDto dto = new UserDto();
+        when(authServices.registerUser(dto)).thenReturn(dto);
+
+        ResponseEntity<?> response = controller.register(dto);
+
+        assertEquals(dto, response.getBody());
+        verify(authServices).registerUser(dto);
+    }
+
+    @Test
+    void loginUserReturnsToken() {
+        UserServicesImp userServices = mock(UserServicesImp.class);
+        AuthServices authServices = mock(AuthServices.class);
+        PasswordEncoder encoder = mock(PasswordEncoder.class);
+        AuthController controller = new AuthController(userServices, authServices, encoder);
+
+        LoginRequest request = new LoginRequest();
+        request.setUsername("u");
+        request.setPassword("p");
+        TokenResponse token = new TokenResponse();
+        when(authServices.attemptLogin("u","p")).thenReturn(token);
+
+        ResponseEntity<TokenResponse> result = controller.loginUser(request);
+
+        assertSame(token, result.getBody());
+        verify(authServices).attemptLogin("u","p");
+    }
+}

--- a/src/test/java/com/example/DocLib/controllers/DoctorControllerTest.java
+++ b/src/test/java/com/example/DocLib/controllers/DoctorControllerTest.java
@@ -1,0 +1,52 @@
+package com.example.DocLib.controllers;
+
+import com.example.DocLib.configruation.UserPrincipleConfig;
+import com.example.DocLib.dto.AddressDto;
+import com.example.DocLib.dto.doctor.DoctorDto;
+import com.example.DocLib.security.UserPrincipleAuthenticationToken;
+import com.example.DocLib.services.implementation.AppointmentServicesImp;
+import com.example.DocLib.services.implementation.DoctorServicesImp;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class DoctorControllerTest {
+
+    @AfterEach
+    void clearContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    private void setAuth(Long id) {
+        UserPrincipleConfig cfg = UserPrincipleConfig.builder()
+                .userId(id)
+                .username("doc")
+                .authorities(Collections.singleton(() -> "ROLE_DOCTOR"))
+                .build();
+        SecurityContextHolder.getContext().setAuthentication(new UserPrincipleAuthenticationToken(cfg));
+    }
+
+    @Test
+    void updateAddressDelegatesToService() {
+        DoctorServicesImp service = mock(DoctorServicesImp.class);
+        AppointmentServicesImp app = mock(AppointmentServicesImp.class);
+        DoctorController controller = new DoctorController(service, app);
+        setAuth(1L);
+
+        AddressDto address = new AddressDto();
+        address.setAddress("new");
+        DoctorDto dto = new DoctorDto();
+        when(service.updateAddress(1L, "new")).thenReturn(dto);
+
+        ResponseEntity<DoctorDto> result = controller.updateAddress(1L, address);
+
+        assertSame(dto, result.getBody());
+        verify(service).updateAddress(1L, "new");
+    }
+}

--- a/src/test/java/com/example/DocLib/controllers/NotificationControllerTest.java
+++ b/src/test/java/com/example/DocLib/controllers/NotificationControllerTest.java
@@ -1,0 +1,17 @@
+package com.example.DocLib.controllers;
+
+import com.example.DocLib.dto.MessageDto;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class NotificationControllerTest {
+    @Test
+    void getMessageReturnsResponse() throws Exception {
+        NotificationController controller = new NotificationController();
+
+        MessageDto result = controller.getMessage(new MessageDto("hello"));
+
+        assertEquals("Message received: hello", result.getName());
+    }
+}

--- a/src/test/java/com/example/DocLib/controllers/PatientControllerTest.java
+++ b/src/test/java/com/example/DocLib/controllers/PatientControllerTest.java
@@ -1,0 +1,65 @@
+package com.example.DocLib.controllers;
+
+import com.example.DocLib.configruation.UserPrincipleConfig;
+import com.example.DocLib.dto.doctor.DoctorDto;
+import com.example.DocLib.dto.patient.PatientDto;
+import com.example.DocLib.security.UserPrincipleAuthenticationToken;
+import com.example.DocLib.services.implementation.PatientServicesImp;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class PatientControllerTest {
+
+    @AfterEach
+    void clearContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    private void setAuth(Long id) {
+        UserPrincipleConfig cfg = UserPrincipleConfig.builder()
+                .userId(id)
+                .username("pat")
+                .authorities(Collections.singleton(() -> "ROLE_PATIENT"))
+                .build();
+        SecurityContextHolder.getContext().setAuthentication(new UserPrincipleAuthenticationToken(cfg));
+    }
+
+    @Test
+    void deleteMeasurementDelegatesToService() {
+        PatientServicesImp service = mock(PatientServicesImp.class);
+        PatientController controller = new PatientController(service);
+        setAuth(1L);
+
+        PatientDto dto = new PatientDto();
+        when(service.deleteMeasurement(1L, 2L)).thenReturn(dto);
+
+        ResponseEntity<PatientDto> result = controller.deleteMeasurement(1L, 2L);
+
+        assertSame(dto, result.getBody());
+        verify(service).deleteMeasurement(1L, 2L);
+    }
+
+    @Test
+    void getPatientDoctorsReturnsList() {
+        PatientServicesImp service = mock(PatientServicesImp.class);
+        PatientController controller = new PatientController(service);
+        setAuth(3L);
+
+        List<DoctorDto> doctors = Arrays.asList(new DoctorDto(), new DoctorDto());
+        when(service.getPatientDoctors(3L)).thenReturn(doctors);
+
+        ResponseEntity<List<DoctorDto>> result = controller.getPatientDoctors(3L);
+
+        assertEquals(2, result.getBody().size());
+        verify(service).getPatientDoctors(3L);
+    }
+}

--- a/src/test/java/com/example/DocLib/security/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/example/DocLib/security/JwtAuthenticationFilterTest.java
@@ -1,0 +1,49 @@
+package com.example.DocLib.security;
+
+import com.auth0.jwt.interfaces.DecodedJWT;
+import com.example.DocLib.configruation.UserPrincipleConfig;
+import jakarta.servlet.FilterChain;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class JwtAuthenticationFilterTest {
+    @AfterEach
+    void clearContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void doFilterInternalSetsAuthentication() throws Exception {
+        JwtDecoder decoder = mock(JwtDecoder.class);
+        JwtPrincipleConverter converter = mock(JwtPrincipleConverter.class);
+        DecodedJWT jwt = mock(DecodedJWT.class);
+        when(decoder.decode("token")).thenReturn(jwt);
+        when(jwt.getClaim("type").asString()).thenReturn("access");
+        UserPrincipleConfig cfg = UserPrincipleConfig.builder()
+                .userId(2L)
+                .username("user")
+                .authorities(Collections.emptyList())
+                .build();
+        when(converter.convert(jwt)).thenReturn(cfg);
+
+        JwtAuthenticationFilter filter = new JwtAuthenticationFilter(decoder, converter);
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Authorization", "Bearer token");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain chain = mock(FilterChain.class);
+
+        filter.doFilterInternal(request, response, chain);
+
+        assertNotNull(SecurityContextHolder.getContext().getAuthentication());
+        assertTrue(SecurityContextHolder.getContext().getAuthentication() instanceof UserPrincipleAuthenticationToken);
+        verify(chain).doFilter(request, response);
+    }
+}

--- a/src/test/java/com/example/DocLib/security/JwtChannelInterceptorTest.java
+++ b/src/test/java/com/example/DocLib/security/JwtChannelInterceptorTest.java
@@ -1,0 +1,44 @@
+package com.example.DocLib.security;
+
+import com.auth0.jwt.interfaces.DecodedJWT;
+import com.example.DocLib.configruation.UserPrincipleConfig;
+import org.junit.jupiter.api.Test;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class JwtChannelInterceptorTest {
+    @Test
+    void preSendSetsUserOnValidToken() {
+        JwtDecoder decoder = mock(JwtDecoder.class);
+        JwtPrincipleConverter converter = mock(JwtPrincipleConverter.class);
+        DecodedJWT jwt = mock(DecodedJWT.class);
+        when(decoder.decode("token")).thenReturn(jwt);
+        when(jwt.getClaim("type").asString()).thenReturn("access");
+        UserPrincipleConfig cfg = UserPrincipleConfig.builder()
+                .userId(10L)
+                .username("u")
+                .authorities(Collections.emptyList())
+                .build();
+        when(converter.convert(jwt)).thenReturn(cfg);
+
+        JwtChannelInterceptor interceptor = new JwtChannelInterceptor(decoder, converter);
+
+        StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.CONNECT);
+        accessor.addNativeHeader("Authorization", "Bearer token");
+        Message<byte[]> message = MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
+
+        Message<?> result = interceptor.preSend(message, mock(MessageChannel.class));
+        StompHeaderAccessor resultAccessor = StompHeaderAccessor.wrap(result);
+        assertNotNull(resultAccessor.getUser());
+        assertTrue(resultAccessor.getUser() instanceof UserPrincipleAuthenticationToken);
+    }
+}

--- a/src/test/java/com/example/DocLib/security/JwtDecoderTest.java
+++ b/src/test/java/com/example/DocLib/security/JwtDecoderTest.java
@@ -1,0 +1,24 @@
+package com.example.DocLib.security;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class JwtDecoderTest {
+    @Test
+    void decodeValidToken() {
+        JwtProperties props = new JwtProperties();
+        props.setSecretKey("secret");
+        String token = JWT.create()
+                .withSubject("42")
+                .withClaim("type", "access")
+                .sign(Algorithm.HMAC256("secret"));
+
+        JwtDecoder decoder = new JwtDecoder(props);
+        var decoded = decoder.decode(token);
+        assertEquals("42", decoded.getSubject());
+        assertEquals("access", decoded.getClaim("type").asString());
+    }
+}

--- a/src/test/java/com/example/DocLib/security/JwtIssuerTest.java
+++ b/src/test/java/com/example/DocLib/security/JwtIssuerTest.java
@@ -1,0 +1,44 @@
+package com.example.DocLib.security;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class JwtIssuerTest {
+    @Test
+    void issueAccessTokenContainsExpectedClaims() {
+        JwtProperties props = new JwtProperties();
+        props.setSecretKey("secret");
+        JwtIssuer issuer = new JwtIssuer(props);
+
+        String token = issuer.issueAccessToken(1L, "user", List.of("USER"));
+        var decoded = JWT.require(Algorithm.HMAC256("secret"))
+                .build()
+                .verify(token);
+
+        assertEquals("1", decoded.getSubject());
+        assertEquals("user", decoded.getClaim("u").asString());
+        assertEquals(List.of("ROLE_USER"), decoded.getClaim("r").asList(String.class));
+        assertEquals("access", decoded.getClaim("type").asString());
+    }
+
+    @Test
+    void issueRefreshTokenContainsTypeRefresh() {
+        JwtProperties props = new JwtProperties();
+        props.setSecretKey("secret");
+        JwtIssuer issuer = new JwtIssuer(props);
+
+        String token = issuer.issueRefreshToken(5L, "user");
+        var decoded = JWT.require(Algorithm.HMAC256("secret"))
+                .build()
+                .verify(token);
+
+        assertEquals("5", decoded.getSubject());
+        assertEquals("user", decoded.getClaim("u").asString());
+        assertEquals("refresh", decoded.getClaim("type").asString());
+    }
+}

--- a/src/test/java/com/example/DocLib/security/JwtPrincipleConverterTest.java
+++ b/src/test/java/com/example/DocLib/security/JwtPrincipleConverterTest.java
@@ -1,0 +1,28 @@
+package com.example.DocLib.security;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class JwtPrincipleConverterTest {
+    @Test
+    void convertAddsRolePrefix() {
+        String token = JWT.create()
+                .withSubject("3")
+                .withClaim("u", "alice")
+                .withClaim("r", java.util.List.of("ADMIN"))
+                .sign(Algorithm.HMAC256("secret"));
+        DecodedJWT jwt = JWT.decode(token);
+
+        JwtPrincipleConverter converter = new JwtPrincipleConverter();
+        var principal = converter.convert(jwt);
+
+        assertEquals(3L, principal.getUserId());
+        assertEquals("alice", principal.getUsername());
+        assertEquals(1, principal.getAuthorities().size());
+        assertEquals("ROLE_ADMIN", principal.getAuthorities().get(0).getAuthority());
+    }
+}

--- a/src/test/java/com/example/DocLib/services/implementation/AppointmentServicesImpTest.java
+++ b/src/test/java/com/example/DocLib/services/implementation/AppointmentServicesImpTest.java
@@ -1,122 +1,64 @@
 package com.example.DocLib.services.implementation;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import com.example.DocLib.dto.doctor.DoctorDto;
+import com.example.DocLib.enums.AppointmentStatus;
+import com.example.DocLib.repositories.AppointmentRepository;
 import org.junit.jupiter.api.Test;
+import org.modelmapper.ModelMapper;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 class AppointmentServicesImpTest {
 
-    @BeforeEach
-    void setUp() {
-    }
+    @Test
+    void isPatientAvailableChecksRepository() {
+        AppointmentRepository repo = mock(AppointmentRepository.class);
+        AppointmentServicesImp service = new AppointmentServicesImp(new ModelMapper(), repo,
+                mock(SimpMessagingTemplate.class), mock(DoctorServicesImp.class),
+                mock(PatientServicesImp.class), mock(UserServicesImp.class));
 
-    @AfterEach
-    void tearDown() {
+        LocalDateTime time = LocalDateTime.now();
+        when(repo.existsByPatientIdAndStartTime(2L, time)).thenReturn(false);
+
+        assertTrue(service.isPatientAvailable(2L, time));
+        verify(repo).existsByPatientIdAndStartTime(2L, time);
     }
 
     @Test
-    void addAppointment() {
+    void isDoctorAvailableChecksOverlaps() {
+        AppointmentRepository repo = mock(AppointmentRepository.class);
+        DoctorServicesImp doctor = mock(DoctorServicesImp.class);
+        AppointmentServicesImp service = new AppointmentServicesImp(new ModelMapper(), repo,
+                mock(SimpMessagingTemplate.class), doctor,
+                mock(PatientServicesImp.class), mock(UserServicesImp.class));
+
+        LocalDateTime start = LocalDateTime.now();
+        DoctorDto dto = new DoctorDto();
+        dto.setCheckupDurationInMinutes(30);
+        when(doctor.getDoctorById(1L)).thenReturn(dto);
+        when(repo.findOverlappingAppointments(eq(1L), eq(start), eq(start.plusMinutes(30)),
+                anyList())).thenReturn(Collections.emptyList());
+
+        assertTrue(service.isDoctorAvailable(1L, start));
     }
 
     @Test
-    void getAppointmentById() {
-    }
+    void getCachedCheckupDurationReturnsFromDoctorService() {
+        AppointmentRepository repo = mock(AppointmentRepository.class);
+        DoctorServicesImp doctor = mock(DoctorServicesImp.class);
+        DoctorDto dto = new DoctorDto();
+        dto.setCheckupDurationInMinutes(20);
+        when(doctor.getDoctorById(1L)).thenReturn(dto);
 
-    @Test
-    void deleteAppointment() {
-    }
+        AppointmentServicesImp service = new AppointmentServicesImp(new ModelMapper(), repo,
+                mock(SimpMessagingTemplate.class), doctor,
+                mock(PatientServicesImp.class), mock(UserServicesImp.class));
 
-    @Test
-    void rescheduleAppointment() {
-    }
-
-    @Test
-    void cancelAppointmentByClinic() {
-    }
-
-    @Test
-    void cancelAppointmentByPatient() {
-    }
-
-    @Test
-    void confirmAppointment() {
-    }
-
-    @Test
-    void updateAppointmentStatus() {
-    }
-
-    @Test
-    void getAppointmentsByDoctor() {
-    }
-
-    @Test
-    void getAppointmentsByPatient() {
-    }
-
-    @Test
-    void getAppointmentsByDateRange() {
-    }
-
-    @Test
-    void getUpcomingAppointmentsForDoctor() {
-    }
-
-    @Test
-    void getUpcomingAppointmentsForPatient() {
-    }
-
-    @Test
-    void isDoctorAvailable() {
-    }
-
-    @Test
-    void isDoctorOnVacation() {
-    }
-
-    @Test
-    void isPatientAvailable() {
-    }
-
-    @Test
-    void getDoctorAvailableSlots() {
-    }
-
-    @Test
-    void getDoctorWeeklySchedule() {
-    }
-
-    @Test
-    void getAppointmentsByStatus() {
-    }
-
-    @Test
-    void checkUpcomingAppointments() {
-    }
-
-    @Test
-    void sendAppointmentReminders() {
-    }
-
-    @Test
-    void getCancelledAppointments() {
-    }
-
-    @Test
-    void getAppointmentCountByStatus() {
-    }
-
-    @Test
-    void getDoctorCancellationRate() {
-    }
-
-    @Test
-    void getPatientHistory() {
-    }
-
-    @Test
-    void getCachedCheckupDuration() {
+        assertEquals(20, service.getCachedCheckupDuration(1L));
     }
 }

--- a/src/test/java/com/example/DocLib/services/implementation/AuthServicesTest.java
+++ b/src/test/java/com/example/DocLib/services/implementation/AuthServicesTest.java
@@ -1,0 +1,70 @@
+package com.example.DocLib.services.implementation;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import com.example.DocLib.enums.Roles;
+import com.example.DocLib.models.User;
+import com.example.DocLib.models.authentication.TokenResponse;
+import com.example.DocLib.repositories.UserRepository;
+import com.example.DocLib.security.JwtDecoder;
+import com.example.DocLib.security.JwtIssuer;
+import com.example.DocLib.security.JwtProperties;
+import org.junit.jupiter.api.Test;
+import org.modelmapper.ModelMapper;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class AuthServicesTest {
+    @Test
+    void refreshTokenReturnsNewTokens() {
+        JwtProperties props = new JwtProperties();
+        props.setSecretKey("secret");
+
+        JwtIssuer issuer = mock(JwtIssuer.class);
+        AuthenticationManager am = mock(AuthenticationManager.class);
+        ModelMapper mapper = new ModelMapper();
+        UserRepository repo = mock(UserRepository.class);
+        PasswordEncoder encoder = mock(PasswordEncoder.class);
+        JwtDecoder decoder = mock(JwtDecoder.class);
+
+        AuthServices service = new AuthServices(issuer, am, mapper, repo, encoder, decoder, props);
+
+        DecodedJWT jwt = mock(DecodedJWT.class);
+        when(decoder.decode("token")).thenReturn(jwt);
+        when(jwt.getClaim("type").asString()).thenReturn("refresh");
+        when(jwt.getSubject()).thenReturn("1");
+        when(jwt.getClaim("u").asString()).thenReturn("user");
+
+        User user = User.builder().id(1L).username("user").role(Roles.ADMIN).build();
+        when(repo.findById(1L)).thenReturn(Optional.of(user));
+        when(issuer.issueAccessToken(1L, "user", List.of("ROLE_ADMIN"))).thenReturn("a");
+        when(issuer.issueRefreshToken(1L, "user")).thenReturn("r");
+
+        TokenResponse response = service.refreshToken("token");
+
+        assertEquals("a", response.getAccessToken());
+        assertEquals("r", response.getRefreshToken());
+        assertEquals(props.getAccessTokenExpirationMs(), response.getExpiresIn());
+    }
+
+    @Test
+    void extractUserIdReturnsSubject() {
+        JwtProperties props = new JwtProperties();
+        props.setSecretKey("secret");
+        JwtIssuer issuer = new JwtIssuer(props);
+        JwtDecoder decoder = new JwtDecoder(props);
+        AuthServices service = new AuthServices(issuer, mock(AuthenticationManager.class), new ModelMapper(),
+                mock(UserRepository.class), mock(PasswordEncoder.class), decoder, props);
+
+        String token = issuer.issueAccessToken(2L, "u", List.of("ROLE_USER"));
+        Long id = service.extractUserId(token);
+        assertEquals(2L, id);
+    }
+}

--- a/src/test/java/com/example/DocLib/services/implementation/CustomUserDetailServiceTest.java
+++ b/src/test/java/com/example/DocLib/services/implementation/CustomUserDetailServiceTest.java
@@ -1,0 +1,39 @@
+package com.example.DocLib.services.implementation;
+
+import com.example.DocLib.enums.Roles;
+import com.example.DocLib.models.User;
+import com.example.DocLib.configruation.UserPrincipleConfig;
+import com.example.DocLib.repositories.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class CustomUserDetailServiceTest {
+    @Test
+    void loadUserByUsernameReturnsPrincipal() {
+        UserRepository repo = mock(UserRepository.class);
+        CustomUserDetailService service = new CustomUserDetailService(repo);
+
+        User user = User.builder()
+                .id(1L)
+                .username("bob")
+                .password("pw")
+                .role(Roles.ADMIN)
+                .build();
+        when(repo.findByUsername("bob")).thenReturn(Optional.of(user));
+
+        UserDetails details = service.loadUserByUsername("bob");
+
+        assertTrue(details instanceof UserPrincipleConfig);
+        UserPrincipleConfig principal = (UserPrincipleConfig) details;
+        assertEquals(1L, principal.getUserId());
+        assertEquals("bob", principal.getUsername());
+        assertEquals("pw", principal.getPassword());
+        assertEquals(1, principal.getAuthorities().size());
+        assertEquals("ROLE_ADMIN", principal.getAuthorities().iterator().next().getAuthority());
+    }
+}

--- a/src/test/java/com/example/DocLib/services/implementation/DrugServicesImpTest.java
+++ b/src/test/java/com/example/DocLib/services/implementation/DrugServicesImpTest.java
@@ -1,0 +1,50 @@
+package com.example.DocLib.services.implementation;
+
+import com.example.DocLib.models.Drug;
+import com.example.DocLib.repositories.DrugRepository;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class DrugServicesImpTest {
+    @Test
+    void getAllDrugsReturnsAll() {
+        DrugRepository repo = mock(DrugRepository.class);
+        DrugServicesImp service = new DrugServicesImp(repo);
+        List<Drug> drugs = List.of(new Drug(), new Drug());
+        when(repo.findAll()).thenReturn(drugs);
+
+        List<Drug> result = service.getAllDrugs();
+
+        assertEquals(drugs, result);
+    }
+
+    @Test
+    void getDrugByIdReturnsDrug() {
+        DrugRepository repo = mock(DrugRepository.class);
+        DrugServicesImp service = new DrugServicesImp(repo);
+        Drug drug = new Drug();
+        when(repo.findById(1L)).thenReturn(Optional.of(drug));
+
+        Drug result = service.getDrugByID(1L);
+
+        assertSame(drug, result);
+    }
+
+    @Test
+    void addDrugSavesDrug() {
+        DrugRepository repo = mock(DrugRepository.class);
+        DrugServicesImp service = new DrugServicesImp(repo);
+        Drug drug = new Drug();
+        when(repo.save(drug)).thenReturn(drug);
+
+        Drug result = service.addDrug(drug);
+
+        assertSame(drug, result);
+        verify(repo).save(drug);
+    }
+}

--- a/src/test/java/com/example/DocLib/services/implementation/UserServicesImpTest.java
+++ b/src/test/java/com/example/DocLib/services/implementation/UserServicesImpTest.java
@@ -1,0 +1,63 @@
+package com.example.DocLib.services.implementation;
+
+import com.example.DocLib.dto.UserDto;
+import com.example.DocLib.models.User;
+import com.example.DocLib.repositories.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.modelmapper.ModelMapper;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class UserServicesImpTest {
+    @Test
+    void findByUsernameMapsUser() {
+        UserRepository repo = mock(UserRepository.class);
+        PasswordEncoder enc = mock(PasswordEncoder.class);
+        ModelMapper mapper = new ModelMapper();
+        UserServicesImp service = new UserServicesImp(repo, enc, mapper);
+
+        User user = User.builder().id(1L).username("name").build();
+        when(repo.findByUsername("name")).thenReturn(Optional.of(user));
+
+        Optional<UserDto> result = service.findByUsername("name");
+
+        assertTrue(result.isPresent());
+        assertEquals("name", result.get().getUsername());
+    }
+
+    @Test
+    void updateUserSavesMappedUser() {
+        UserRepository repo = mock(UserRepository.class);
+        PasswordEncoder enc = mock(PasswordEncoder.class);
+        ModelMapper mapper = new ModelMapper();
+        UserServicesImp service = new UserServicesImp(repo, enc, mapper);
+
+        UserDto dto = UserDto.builder().id(3L).username("new").password("p").build();
+        when(repo.findById(3L)).thenReturn(Optional.of(new User()));
+        when(repo.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        UserDto result = service.updateUser(3L, dto);
+
+        assertEquals("new", result.getUsername());
+    }
+
+    @Test
+    void getUserReturnsMappedUser() {
+        UserRepository repo = mock(UserRepository.class);
+        PasswordEncoder enc = mock(PasswordEncoder.class);
+        ModelMapper mapper = new ModelMapper();
+        UserServicesImp service = new UserServicesImp(repo, enc, mapper);
+
+        User user = User.builder().id(5L).username("bob").build();
+        when(repo.findById(5L)).thenReturn(Optional.of(user));
+
+        UserDto result = service.getUser(5L);
+
+        assertEquals("bob", result.getUsername());
+    }
+}


### PR DESCRIPTION
## Summary
- implement AuthServicesTest with token refresh and extraction
- cover CustomUserDetailService loadByUsername
- add tests for DrugServicesImp CRUD operations
- create UserServicesImp tests for basic user management
- replace placeholder AppointmentServicesImpTest with real tests
- add controller unit tests for Auth, Appointment, Doctor, Patient, Notification controllers

## Testing
- `./mvnw -q test` *(fails: wget failed to fetch Maven)*

------
https://chatgpt.com/codex/tasks/task_e_684aff87c8088331b9ecfdc352efe9a8