### PR TITLE
Normalize REST endpoint URLs

### DIFF
--- a/src/main/java/com/example/DocLib/controllers/DoctorController.java
+++ b/src/main/java/com/example/DocLib/controllers/DoctorController.java
@@ -52,7 +52,7 @@ import java.util.List;
  */
 
 @RestController
-@RequestMapping("/doctor")
+@RequestMapping("/doctors")
 public class DoctorController {
     private final DoctorServicesImp doctorServicesImp;
     private final AppointmentServicesImp appointmentServicesImp;
@@ -78,7 +78,7 @@ public class DoctorController {
      *
      * @return A ResponseEntity containing a list of DoctorDto objects representing all doctors.
      */
-    @GetMapping("/all")
+    @GetMapping("")
     public ResponseEntity<List<DoctorDto>> getAllDoctors() {
         List<DoctorDto> doctors = doctorServicesImp.getAllDoctors();
         return ResponseEntity.ok(doctors);
@@ -103,7 +103,7 @@ public class DoctorController {
     /**
      *
      */
-    @PostMapping("/{id}/specialization")
+    @PostMapping("/{id}/specializations")
     public ResponseEntity<DoctorDto> addSpecialization(@PathVariable Long id, @RequestBody @Valid SpecializationsDto specializationDto) {
         checkAuthenticatedUser(id);
         DoctorDto updatedDoctor = doctorServicesImp.addSpecialization(id, specializationDto);
@@ -154,7 +154,7 @@ public class DoctorController {
     /**
      *
      */
-    @PostMapping("/{doctorId}/experiences/delete/{experienceId}")
+    @PostMapping("/{doctorId}/experiences/{experienceId}")
     public ResponseEntity<DoctorDto> removeExperience(@PathVariable Long doctorId, @PathVariable  Long experienceId) {
         checkAuthenticatedUser(doctorId);
         DoctorDto updatedDoctor = doctorServicesImp.removeExperience(doctorId, experienceId);
@@ -194,7 +194,7 @@ public class DoctorController {
      * @param scientificBackgroundId The ID of the scientific background to be removed
      * @return ResponseEntity containing the updated DoctorDto after removing the scientific background
      */
-    @PostMapping("/{doctorId}/scientific-backgrounds/delete/{scientificBackgroundId}")
+    @PostMapping("/{doctorId}/scientific-backgrounds/{scientificBackgroundId}")
     public ResponseEntity<DoctorDto> removeScientificBackground(@PathVariable Long doctorId, @PathVariable Long scientificBackgroundId) {
         checkAuthenticatedUser(doctorId);
         DoctorDto updatedDoctor = doctorServicesImp.removeScientificBackground(doctorId, scientificBackgroundId);
@@ -220,7 +220,7 @@ public class DoctorController {
     /**
      *
      */
-    @PostMapping("/{doctorId}/services/delete/{serviceId}")
+    @PostMapping("/{doctorId}/services/{serviceId}")
     public ResponseEntity<DoctorDto> removeService(@PathVariable Long doctorId, @PathVariable Long serviceId) {
         checkAuthenticatedUser(doctorId);
         DoctorDto updatedDoctor = doctorServicesImp.removeService(doctorId, serviceId);
@@ -271,7 +271,7 @@ public class DoctorController {
      * @param doctorHolidayScheduleId the ID of the holiday schedule to remove
      * @return ResponseEntity containing the updated DoctorDto after removing the holiday schedule
      */
-    @PostMapping("/{doctorId}/holiday-schedules/delete/{doctorHolidayScheduleId}")
+    @PostMapping("/{doctorId}/holiday-schedules/{doctorHolidayScheduleId}")
     public ResponseEntity<DoctorDto> removeHolidaySchedule(@PathVariable Long doctorId, @PathVariable Long doctorHolidayScheduleId) {
         checkAuthenticatedUser(doctorId);
         DoctorDto updatedDoctor = doctorServicesImp.removeHolidaySchedule(doctorId, doctorHolidayScheduleId);
@@ -359,7 +359,7 @@ public class DoctorController {
     /**
      *
      */
-    @PostMapping("/{doctorId}/specializations/delete/{specializationId}")
+    @PostMapping("/{doctorId}/specializations/{specializationId}")
     public ResponseEntity<DoctorDto> removeSpecialization(@PathVariable Long doctorId, @PathVariable Long specializationId) {
         checkAuthenticatedUser(doctorId);
         DoctorDto updatedDoctor = doctorServicesImp.removeSpecialization(doctorId, specializationId);
@@ -422,7 +422,7 @@ public class DoctorController {
         return ResponseEntity.ok(updatedDoctor);
     }
 
-    @PutMapping("/{doctorId}/CheckupDuration")
+    @PutMapping("/{doctorId}/checkup-duration")
     public ResponseEntity<DoctorDto> updateCheckupDuration(@PathVariable Long doctorId,@RequestBody @Valid IntegerDto integerDto){
         checkAuthenticatedUser(doctorId);
         DoctorDto doctorDto = doctorServicesImp.updateCheckupDuration(doctorId,integerDto);

--- a/src/main/java/com/example/DocLib/controllers/NotificationController.java
+++ b/src/main/java/com/example/DocLib/controllers/NotificationController.java
@@ -13,7 +13,7 @@ import java.util.Map;
 public class NotificationController {
 
 
-    @MessageMapping("/sendMassage")
+    @MessageMapping("/send-message")
     @SendTo("/queue/appointments")
     public MessageDto getMessage(MessageDto message) throws InterruptedException {
         System.out.println("Received: " + message.getName());

--- a/src/main/java/com/example/DocLib/controllers/PatientController.java
+++ b/src/main/java/com/example/DocLib/controllers/PatientController.java
@@ -18,11 +18,11 @@ import java.util.List;
  * <p>All routes require the authenticated user to match the {@code patientId} in the path.
  * If the authenticated user ID does not match, an {@link AccessDeniedException} is thrown.</p>
  *
- * <p>Base path: {@code /patient}</p>
+ * <p>Base path: {@code /patients}</p>
  * @author Janbout Hakim
  **/
 @RestController
-@RequestMapping("/patient")
+@RequestMapping("/patients")
 public class PatientController {
 
     private final PatientServicesImp patientServicesImp;
@@ -39,7 +39,7 @@ public class PatientController {
      * @return Updated patient information.
      * @throws AccessDeniedException if the authenticated user is not the owner of the record.
      */
-    @DeleteMapping("/{patientId}/Measurement/{measurementId}")
+    @DeleteMapping("/{patientId}/measurements/{measurementId}")
     public ResponseEntity<PatientDto> deleteMeasurement(@PathVariable Long patientId, @PathVariable Long measurementId) {
         checkAuthenticatedUser(patientId);
         PatientDto patientDto = patientServicesImp.deleteMeasurement(patientId, measurementId);
@@ -60,7 +60,7 @@ public class PatientController {
      * @return Updated patient information.
      * @throws AccessDeniedException if the authenticated user is not the owner of the record.
      */
-    @PostMapping("/{patientId}/Drug")
+    @PostMapping("/{patientId}/drugs")
     public ResponseEntity<PatientDto> updateDrug(@PathVariable Long patientId, @RequestBody @Valid PatientDrugDto patientDrugDto) {
         checkAuthenticatedUser(patientId);
         PatientDto patientDto = patientServicesImp.updateDrug(patientId, patientDrugDto);
@@ -75,7 +75,7 @@ public class PatientController {
      * @return Updated patient information.
      * @throws AccessDeniedException if the authenticated user is not the owner of the record.
      */
-    @PostMapping("/{patientId}/Analyse")
+    @PostMapping("/{patientId}/analyses")
     public ResponseEntity<PatientDto> updateAnalyse(@PathVariable Long patientId, @RequestBody @Valid AnalyseDto analyseDto) {
         checkAuthenticatedUser(patientId);
         PatientDto patientDto = patientServicesImp.updateAnalyse(patientId, analyseDto);
@@ -91,7 +91,7 @@ public class PatientController {
      * @return Updated patient information (currently returns empty DTO).
      * @throws AccessDeniedException if the authenticated user is not the owner of the record.
      */
-    @PostMapping("/{patientId}/InsuranceCompany")
+    @PostMapping("/{patientId}/insurance-company")
     public ResponseEntity<PatientDto> updateInsuranceCompany(@PathVariable Long patientId, @RequestBody @Valid InsuranceCompanyDto insuranceCompanyDto) {
         checkAuthenticatedUser(patientId);
         // Currently not implemented
@@ -106,7 +106,7 @@ public class PatientController {
      * @return Updated patient information.
      * @throws AccessDeniedException if the authenticated user is not the owner of the record.
      */
-    @PostMapping("/{patientId}/getAllMeasurement")
+    @PostMapping("/{patientId}/measurements")
     public ResponseEntity<PatientDto> updateMeasurement(@PathVariable Long patientId, @RequestBody @Valid MeasurementDto measurementDto) {
         checkAuthenticatedUser(patientId);
         PatientDto patientDto = patientServicesImp.updateMeasurement(patientId, measurementDto);
@@ -121,7 +121,7 @@ public class PatientController {
      * @return Updated patient information.
      * @throws AccessDeniedException if the authenticated user is not the owner of the record.
      */
-    @PostMapping("/{patientId}/updateHistory")
+    @PostMapping("/{patientId}/history")
     public ResponseEntity<PatientDto> updateHistoryRecord(@PathVariable Long patientId, @RequestBody @Valid PatientHistoryRecordDto historyDto) {
         checkAuthenticatedUser(patientId);
         PatientDto patientDto = patientServicesImp.updateHistoryRecord(patientId, historyDto);


### PR DESCRIPTION
## Summary
- rename `/patient` routes to `/patients`
- standardize doctor controller path names and base path
- fix message mapping typo in `NotificationController`

## Testing
- `mvnw -q test` *(fails: failed to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684b3c34cfa4833192f33b6ecfe6a571