### PR TITLE
Add unit tests for controllers

### DIFF
--- a/src/test/java/com/example/DocLib/controllers/AppointmentControllerTest.java
+++ b/src/test/java/com/example/DocLib/controllers/AppointmentControllerTest.java
@@ -10,6 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
 
 import java.util.Collections;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -59,5 +60,61 @@ class AppointmentControllerTest {
 
         assertSame(dto, result.getBody());
         verify(service).cancelAppointmentByClinic(3L, "r");
+    }
+
+    @Test
+    void addAppointmentDelegatesToService() {
+        AppointmentServicesImp service = mock(AppointmentServicesImp.class);
+        AppointmentController controller = new AppointmentController(service);
+        setAuth(5L, "ROLE_PATIENT");
+
+        AppointmentDto dto = new AppointmentDto();
+        when(service.addAppointment(dto)).thenReturn(dto);
+
+        ResponseEntity<AppointmentDto> result = controller.addAppointment(5L, dto);
+
+        assertSame(dto, result.getBody());
+        verify(service).addAppointment(dto);
+    }
+
+    @Test
+    void deleteAppointmentInvokesService() {
+        AppointmentServicesImp service = mock(AppointmentServicesImp.class);
+        AppointmentController controller = new AppointmentController(service);
+        setAuth(4L, "ROLE_PATIENT");
+
+        ResponseEntity<Void> result = controller.deleteAppointment(7L, 4L);
+
+        assertEquals(204, result.getStatusCode().value());
+        verify(service).deleteAppointment(7L);
+    }
+
+    @Test
+    void getAppointmentsByDoctorReturnsList() {
+        AppointmentServicesImp service = mock(AppointmentServicesImp.class);
+        AppointmentController controller = new AppointmentController(service);
+        setAuth(6L, "ROLE_PATIENT");
+
+        when(service.getAppointmentsByDoctor(3L)).thenReturn(Collections.emptyList());
+
+        ResponseEntity<List<AppointmentDto>> result = controller.getAppointmentsByDoctor(3L, 6L);
+
+        assertNotNull(result.getBody());
+        verify(service).getAppointmentsByDoctor(3L);
+    }
+
+    @Test
+    void confirmAppointmentDelegatesToService() {
+        AppointmentServicesImp service = mock(AppointmentServicesImp.class);
+        AppointmentController controller = new AppointmentController(service);
+        setAuth(8L, "ROLE_DOCTOR");
+
+        AppointmentDto dto = new AppointmentDto();
+        when(service.confirmAppointment(9L)).thenReturn(dto);
+
+        ResponseEntity<AppointmentDto> result = controller.confirmAppointment(9L, 8L);
+
+        assertSame(dto, result.getBody());
+        verify(service).confirmAppointment(9L);
     }
 }

--- a/src/test/java/com/example/DocLib/controllers/AuthControllerTest.java
+++ b/src/test/java/com/example/DocLib/controllers/AuthControllerTest.java
@@ -3,6 +3,7 @@ package com.example.DocLib.controllers;
 import com.example.DocLib.dto.UserDto;
 import com.example.DocLib.models.authentication.LoginRequest;
 import com.example.DocLib.models.authentication.TokenResponse;
+import com.example.DocLib.dto.RefreshTokenRequest;
 import com.example.DocLib.services.implementation.AuthServices;
 import com.example.DocLib.services.implementation.UserServicesImp;
 import org.junit.jupiter.api.Test;
@@ -46,5 +47,21 @@ class AuthControllerTest {
 
         assertSame(token, result.getBody());
         verify(authServices).attemptLogin("u","p");
+    }
+
+    @Test
+    void refreshTokenUsesService() {
+        UserServicesImp userServices = mock(UserServicesImp.class);
+        AuthServices authServices = mock(AuthServices.class);
+        PasswordEncoder encoder = mock(PasswordEncoder.class);
+        AuthController controller = new AuthController(userServices, authServices, encoder);
+
+        TokenResponse token = new TokenResponse();
+        when(authServices.refreshToken("r")).thenReturn(token);
+
+        ResponseEntity<TokenResponse> result = controller.refreshToken(new RefreshTokenRequest("r"));
+
+        assertSame(token, result.getBody());
+        verify(authServices).refreshToken("r");
     }
 }

--- a/src/test/java/com/example/DocLib/controllers/DoctorControllerTest.java
+++ b/src/test/java/com/example/DocLib/controllers/DoctorControllerTest.java
@@ -12,6 +12,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
 
 import java.util.Collections;
+import java.util.List;
+import java.time.LocalDateTime;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -48,5 +50,48 @@ class DoctorControllerTest {
 
         assertSame(dto, result.getBody());
         verify(service).updateAddress(1L, "new");
+    }
+
+    @Test
+    void getDoctorByIdReturnsFromService() {
+        DoctorServicesImp service = mock(DoctorServicesImp.class);
+        AppointmentServicesImp app = mock(AppointmentServicesImp.class);
+        DoctorController controller = new DoctorController(service, app);
+
+        DoctorDto dto = new DoctorDto();
+        when(service.getDoctorById(3L)).thenReturn(dto);
+
+        ResponseEntity<DoctorDto> result = controller.getDoctorById(3L);
+
+        assertSame(dto, result.getBody());
+        verify(service).getDoctorById(3L);
+    }
+
+    @Test
+    void getAllDoctorsReturnsList() {
+        DoctorServicesImp service = mock(DoctorServicesImp.class);
+        AppointmentServicesImp app = mock(AppointmentServicesImp.class);
+        DoctorController controller = new DoctorController(service, app);
+
+        when(service.getAllDoctors()).thenReturn(Collections.emptyList());
+
+        ResponseEntity<List<DoctorDto>> result = controller.getAllDoctors();
+
+        assertNotNull(result.getBody());
+        verify(service).getAllDoctors();
+    }
+
+    @Test
+    void getDoctorAvailableSlotsUsesAppointmentService() {
+        DoctorServicesImp service = mock(DoctorServicesImp.class);
+        AppointmentServicesImp app = mock(AppointmentServicesImp.class);
+        DoctorController controller = new DoctorController(service, app);
+
+        when(app.getDoctorAvailableSlots(7L)).thenReturn(Collections.emptyList());
+
+        ResponseEntity<List<LocalDateTime>> result = controller.getDoctorAvailableSlots(7L);
+
+        assertNotNull(result.getBody());
+        verify(app).getDoctorAvailableSlots(7L);
     }
 }

--- a/src/test/java/com/example/DocLib/controllers/PatientControllerTest.java
+++ b/src/test/java/com/example/DocLib/controllers/PatientControllerTest.java
@@ -3,6 +3,8 @@ package com.example.DocLib.controllers;
 import com.example.DocLib.configruation.UserPrincipleConfig;
 import com.example.DocLib.dto.doctor.DoctorDto;
 import com.example.DocLib.dto.patient.PatientDto;
+import com.example.DocLib.dto.patient.PatientDrugDto;
+import com.example.DocLib.dto.patient.PatientHistoryRecordDto;
 import com.example.DocLib.security.UserPrincipleAuthenticationToken;
 import com.example.DocLib.services.implementation.PatientServicesImp;
 import org.junit.jupiter.api.AfterEach;
@@ -61,5 +63,37 @@ class PatientControllerTest {
 
         assertEquals(2, result.getBody().size());
         verify(service).getPatientDoctors(3L);
+    }
+
+    @Test
+    void updateDrugSetsIdAndCallsService() {
+        PatientServicesImp service = mock(PatientServicesImp.class);
+        PatientController controller = new PatientController(service);
+        setAuth(4L);
+
+        PatientDrugDto drugDto = new PatientDrugDto();
+        when(service.updateDrug(4L, drugDto)).thenReturn(new PatientDto());
+
+        ResponseEntity<PatientDto> result = controller.updateDrug(4L, 9L, drugDto);
+
+        assertNotNull(result.getBody());
+        assertEquals(9L, drugDto.getId());
+        verify(service).updateDrug(4L, drugDto);
+    }
+
+    @Test
+    void updateHistoryRecordDelegatesToService() {
+        PatientServicesImp service = mock(PatientServicesImp.class);
+        PatientController controller = new PatientController(service);
+        setAuth(5L);
+
+        PatientHistoryRecordDto dto = new PatientHistoryRecordDto();
+        when(service.updateHistoryRecord(5L, dto)).thenReturn(new PatientDto());
+
+        ResponseEntity<PatientDto> result = controller.updateHistoryRecord(5L, 11L, dto);
+
+        assertNotNull(result.getBody());
+        assertEquals(11L, dto.getId());
+        verify(service).updateHistoryRecord(5L, dto);
     }
 }


### PR DESCRIPTION
## Summary
- extend controller unit tests with additional endpoint coverage

## Testing
- `./mvnw -q test` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684b419f122083319fbdd4014f8c2275