### PR TITLE
Add validation annotations to DTOs

### DIFF
--- a/src/main/java/com/example/DocLib/dto/AddressDto.java
+++ b/src/main/java/com/example/DocLib/dto/AddressDto.java
@@ -1,8 +1,12 @@
 package com.example.DocLib.dto;
 
 import lombok.Data;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 @Data
 public class AddressDto {
+    @NotBlank(message = "Address is required")
+    @Size(min = 2, max = 255, message = "Address must be between 2 and 255 characters")
     private String address;
 }

--- a/src/main/java/com/example/DocLib/dto/ErrorResponse.java
+++ b/src/main/java/com/example/DocLib/dto/ErrorResponse.java
@@ -4,13 +4,18 @@ package com.example.DocLib.dto;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
 public class ErrorResponse {
 
-    private int statusCode;
+    @NotNull
+    private Integer statusCode;
+
+    @NotBlank
     private String message;
 
     public ErrorResponse(String message)

--- a/src/main/java/com/example/DocLib/dto/InsuranceCompanyDto.java
+++ b/src/main/java/com/example/DocLib/dto/InsuranceCompanyDto.java
@@ -2,6 +2,7 @@ package com.example.DocLib.dto;
 
 import com.example.DocLib.enums.InsuranceCompanies;
 import lombok.*;
+import jakarta.validation.constraints.NotNull;
 
 @AllArgsConstructor
 @NoArgsConstructor
@@ -11,7 +12,10 @@ import lombok.*;
 @Data
 public class InsuranceCompanyDto {
 
+    @NotNull(message = "Insurance ID is required")
     private Long insuranceId;
+
+    @NotNull(message = "Company name is required")
     private InsuranceCompanies companyName;
 
 }

--- a/src/main/java/com/example/DocLib/dto/MessageDto.java
+++ b/src/main/java/com/example/DocLib/dto/MessageDto.java
@@ -2,10 +2,14 @@ package com.example.DocLib.dto;
 
 import lombok.Getter;
 import lombok.Setter;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 @Getter
 @Setter
 public class MessageDto {
+    @NotBlank(message = "Name is required")
+    @Size(max = 255, message = "Name must be at most 255 characters")
     private String name;
 
     public MessageDto() {}

--- a/src/main/java/com/example/DocLib/dto/appointment/AppointmentNotificationDto.java
+++ b/src/main/java/com/example/DocLib/dto/appointment/AppointmentNotificationDto.java
@@ -4,13 +4,20 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 @Getter
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
 public class AppointmentNotificationDto {
+    @NotBlank(message = "Content is required")
+    @Size(max = 255, message = "Content must be at most 255 characters")
     private String content;
+
+    @NotNull(message = "Appointment is required")
     private AppointmentDto appointmentDto;
 
 

--- a/src/main/java/com/example/DocLib/dto/appointment/LocalDateTimeBlock.java
+++ b/src/main/java/com/example/DocLib/dto/appointment/LocalDateTimeBlock.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import jakarta.validation.constraints.NotNull;
 
 import java.time.LocalDateTime;
 
@@ -13,8 +14,11 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 public class LocalDateTimeBlock {
+    @NotNull
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private LocalDateTime start;
+
+    @NotNull
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private LocalDateTime end;
 }

--- a/src/main/java/com/example/DocLib/dto/appointment/MonthsDto.java
+++ b/src/main/java/com/example/DocLib/dto/appointment/MonthsDto.java
@@ -1,8 +1,12 @@
 package com.example.DocLib.dto.appointment;
 
 import lombok.Data;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 
 @Data
 public class MonthsDto {
+    @Min(value = 1, message = "Months must be at least 1")
+    @Max(value = 12, message = "Months must be at most 12")
     private int months;
 }

--- a/src/main/java/com/example/DocLib/dto/doctor/DoctorDto.java
+++ b/src/main/java/com/example/DocLib/dto/doctor/DoctorDto.java
@@ -6,6 +6,8 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
 
 import java.util.List;
 
@@ -17,14 +19,18 @@ public class DoctorDto {
 
     private Long id;
 
+    @NotBlank(message = "Address is required")
     private String address;
 
+    @Min(value = 1, message = "Checkup duration must be positive")
     private int checkupDurationInMinutes;
 
     private List<SpecializationsDto> specialization;
 
+    @Min(value = 0, message = "Years of experience cannot be negative")
     private int yearsOfExperience;
 
+    @NotBlank(message = "Union membership number is required")
     private String unionMembershipNumber;
 
     private List<AppointmentDto> appointments;

--- a/src/main/java/com/example/DocLib/dto/doctor/TimeBlock.java
+++ b/src/main/java/com/example/DocLib/dto/doctor/TimeBlock.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import jakarta.validation.constraints.NotNull;
 
 import java.time.LocalTime;
 
@@ -12,7 +13,10 @@ import java.time.LocalTime;
 @NoArgsConstructor
 @AllArgsConstructor
 public class TimeBlock {
+    @NotNull
     private LocalTime start;
+
+    @NotNull
     private LocalTime end;
 
 }

--- a/src/main/java/com/example/DocLib/dto/patient/PatientDto.java
+++ b/src/main/java/com/example/DocLib/dto/patient/PatientDto.java
@@ -7,6 +7,7 @@ import com.example.DocLib.models.patient.Measurement;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import jakarta.validation.constraints.NotBlank;
 
 import java.util.List;
 
@@ -18,6 +19,7 @@ public class PatientDto   {
 
     private Long patientId;
 
+    @NotBlank(message = "Address is required")
     private String address;
 
     private List<AnalyseDto> analyses;


### PR DESCRIPTION
## Summary
- ensure DTOs without constraints include Jakarta validation
- enforce required fields in `AddressDto`, `MessageDto`, `InsuranceCompanyDto` and other objects

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_684c4ef50cd08331996ae3f11f9a524d