### PR TITLE
Fix appointment overlap and caching

### DIFF
--- a/src/main/java/com/example/DocLib/models/appointment/Appointment.java
+++ b/src/main/java/com/example/DocLib/models/appointment/Appointment.java
@@ -4,13 +4,14 @@ import com.example.DocLib.enums.AppointmentStatus;
 import com.example.DocLib.models.doctor.Doctor;
 import com.example.DocLib.models.patient.Patient;
 import jakarta.persistence.*;
-import jakarta.validation.constraints.Null;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.time.LocalDateTime;
+
+import static java.time.LocalDateTime.now;
 
 @Getter
 @Setter
@@ -40,8 +41,19 @@ public class Appointment {
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
-    @Enumerated
+    @Enumerated(EnumType.STRING)
     private AppointmentStatus status;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = now();
+        updatedAt = createdAt;
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = now();
+    }
 
 
 

--- a/src/main/java/com/example/DocLib/repositories/AppointmentRepository.java
+++ b/src/main/java/com/example/DocLib/repositories/AppointmentRepository.java
@@ -28,6 +28,16 @@ public interface AppointmentRepository extends JpaRepository<Appointment,Long> {
                                                   @Param("startTime") LocalDateTime startTime,
                                                   @Param("endTime") LocalDateTime endTime,
                                                   @Param("statuses") List<AppointmentStatus> statuses);
+
+    @Query("SELECT a FROM Appointment a WHERE a.patient.id = :patientId " +
+            "AND a.status IN :statuses " +
+            "AND ((:startTime BETWEEN a.startTime AND a.endTime) OR " +
+            "(:endTime BETWEEN a.startTime AND a.endTime) OR " +
+            "(a.startTime BETWEEN :startTime AND :endTime))")
+    List<Appointment> findOverlappingAppointmentsForPatient(@Param("patientId") Long patientId,
+                                                            @Param("startTime") LocalDateTime startTime,
+                                                            @Param("endTime") LocalDateTime endTime,
+                                                            @Param("statuses") List<AppointmentStatus> statuses);
     @Query("SELECT a FROM Appointment a WHERE " +
             "((:startTime BETWEEN a.startTime AND a.endTime) OR " +
             "(:endTime BETWEEN a.startTime AND a.endTime) OR " +

--- a/src/main/java/com/example/DocLib/services/implementation/AppointmentServicesImp.java
+++ b/src/main/java/com/example/DocLib/services/implementation/AppointmentServicesImp.java
@@ -70,7 +70,7 @@ public class AppointmentServicesImp implements AppointmentServices {
         if (!isDoctorAvailable(appointmentDto.getDoctorId(), appointmentDto.getStartTime()) ||
                 isDoctorOnVacation(appointmentDto.getDoctorId(), appointmentDto.getStartTime())) {
             throw new AppointmentNotAvailableAtThisTime("Doctor is not available at the requested time.");
-        } else if (!isPatientAvailable(appointmentDto.getPatientId(), appointmentDto.getStartTime())) {
+        } else if (!isPatientAvailable(appointmentDto.getPatientId(), appointmentDto.getDoctorId(), appointmentDto.getStartTime())) {
             throw new AppointmentNotAvailableAtThisTime("Patient is not available at the requested time.");
         }
 
@@ -108,7 +108,7 @@ public class AppointmentServicesImp implements AppointmentServices {
         if (!isDoctorAvailable(appointmentDto.getDoctorId(), appointmentDto.getStartTime()) ||
                 isDoctorOnVacation(appointmentDto.getDoctorId(), appointmentDto.getStartTime())) {
             throw new AppointmentNotAvailableAtThisTime("Doctor is not available at the requested time.");
-        } else if (!isPatientAvailable(appointmentDto.getPatientId(), appointmentDto.getStartTime())) {
+        } else if (!isPatientAvailable(appointmentDto.getPatientId(), appointmentDto.getDoctorId(), appointmentDto.getStartTime())) {
             throw new AppointmentNotAvailableAtThisTime("Patient is not available at the requested time.");
         }
 
@@ -211,8 +211,12 @@ public class AppointmentServicesImp implements AppointmentServices {
     }
 
     @Override
-    public boolean isPatientAvailable(Long patientId, LocalDateTime startTime) {
-        return !appointmentRepository.existsByPatientIdAndStartTime(patientId, startTime);
+    public boolean isPatientAvailable(Long patientId, Long doctorId, LocalDateTime startTime) {
+        LocalDateTime endTime = startTime.plusMinutes(getCachedCheckupDuration(doctorId));
+        return appointmentRepository.findOverlappingAppointmentsForPatient(
+                patientId, startTime, endTime,
+                List.of(AppointmentStatus.CONFIRMED, AppointmentStatus.ON_HOLD)
+        ).isEmpty();
     }
 
     @Override

--- a/src/main/java/com/example/DocLib/services/implementation/DoctorServicesImp.java
+++ b/src/main/java/com/example/DocLib/services/implementation/DoctorServicesImp.java
@@ -11,6 +11,7 @@ import jakarta.persistence.EntityNotFoundException;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -200,6 +201,7 @@ public class DoctorServicesImp implements DoctorServices {
     // Schedule operations
     @Override
     @Transactional
+    @CacheEvict(value = "availableSlots", key = "#doctorId")
     public DoctorDto addSchedule(Long doctorId, DoctorScheduleDto dto) {
         Doctor doctor = getDoctorEntity(doctorId);
         DoctorSchedule schedule = modelMapper.map(dto, DoctorSchedule.class);

--- a/src/main/java/com/example/DocLib/services/interfaces/AppointmentServices.java
+++ b/src/main/java/com/example/DocLib/services/interfaces/AppointmentServices.java
@@ -31,7 +31,7 @@ public interface AppointmentServices {
         List<AppointmentDto> getUpcomingAppointmentsForDoctor(Long doctorId);
 
         // Availability Checking
-        boolean isPatientAvailable(Long patientId, LocalDateTime startTime);
+        boolean isPatientAvailable(Long patientId, Long doctorId, LocalDateTime startTime);
         boolean isDoctorAvailable(Long doctorId, LocalDateTime dateTime);
         boolean isDoctorOnVacation(Long doctorId, LocalDateTime startTime);
         List<LocalDateTime> getDoctorAvailableSlots(Long doctorId);

--- a/src/test/java/com/example/DocLib/services/implementation/AppointmentServicesImpTest.java
+++ b/src/test/java/com/example/DocLib/services/implementation/AppointmentServicesImpTest.java
@@ -18,15 +18,20 @@ class AppointmentServicesImpTest {
     @Test
     void isPatientAvailableChecksRepository() {
         AppointmentRepository repo = mock(AppointmentRepository.class);
+        DoctorServicesImp doctor = mock(DoctorServicesImp.class);
         AppointmentServicesImp service = new AppointmentServicesImp(new ModelMapper(), repo,
-                mock(SimpMessagingTemplate.class), mock(DoctorServicesImp.class),
+                mock(SimpMessagingTemplate.class), doctor,
                 mock(PatientServicesImp.class), mock(UserServicesImp.class));
 
         LocalDateTime time = LocalDateTime.now();
-        when(repo.existsByPatientIdAndStartTime(2L, time)).thenReturn(false);
+        DoctorDto dto = new DoctorDto();
+        dto.setCheckupDurationInMinutes(30);
+        when(doctor.getDoctorById(1L)).thenReturn(dto);
+        when(repo.findOverlappingAppointmentsForPatient(eq(2L), eq(time), eq(time.plusMinutes(30)), anyList()))
+                .thenReturn(Collections.emptyList());
 
-        assertTrue(service.isPatientAvailable(2L, time));
-        verify(repo).existsByPatientIdAndStartTime(2L, time);
+        assertTrue(service.isPatientAvailable(2L, 1L, time));
+        verify(repo).findOverlappingAppointmentsForPatient(eq(2L), eq(time), eq(time.plusMinutes(30)), anyList());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- add createdAt/updatedAt lifecycle hooks on appointments
- check patient schedule overlap when booking
- refresh cached slot availability when schedules are added for a doctor
- update related interfaces and tests

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68514f983fe08331a1c0a7a50536e5aa