### PR TITLE
Add validation error handler

### DIFF
--- a/src/main/java/com/example/DocLib/configruation/GlobalExceptionHandlerConfig.java
+++ b/src/main/java/com/example/DocLib/configruation/GlobalExceptionHandlerConfig.java
@@ -1,17 +1,20 @@
 package com.example.DocLib.configruation;
 
 import com.example.DocLib.exceptions.ErrorObject;
-import com.example.DocLib.exceptions.custom.AccessDeniedException;
 import com.example.DocLib.exceptions.custom.AppointmentNotAvailableAtThisTime;
 import com.example.DocLib.exceptions.custom.ResourceNotFoundException;
+import jakarta.validation.ConstraintViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
 import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
 
 @ControllerAdvice
 public class GlobalExceptionHandlerConfig {
@@ -36,6 +39,22 @@ public class GlobalExceptionHandlerConfig {
     public ResponseEntity<String> handleMaxSizeException(MaxUploadSizeExceededException exc) {
         return ResponseEntity.status(HttpStatus.PAYLOAD_TOO_LARGE)
                 .body("File is too large! Please upload a smaller file.");
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Map<String, String>> handleMethodArgumentNotValid(MethodArgumentNotValidException ex) {
+        Map<String, String> errors = new HashMap<>();
+        ex.getBindingResult().getFieldErrors().forEach(error ->
+                errors.put(error.getField(), error.getDefaultMessage()));
+        return new ResponseEntity<>(errors, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<Map<String, String>> handleConstraintViolation(ConstraintViolationException ex) {
+        Map<String, String> errors = new HashMap<>();
+        ex.getConstraintViolations().forEach(violation ->
+                errors.put(violation.getPropertyPath().toString(), violation.getMessage()));
+        return new ResponseEntity<>(errors, HttpStatus.BAD_REQUEST);
     }
 
 


### PR DESCRIPTION
## Summary
- improve `GlobalExceptionHandlerConfig` to return validation errors

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_685430fe5704833193cf26b44042828f