### PR TITLE
Restrict appointment search to logged in user

### DIFF
--- a/src/main/java/com/example/DocLib/controllers/AppointmentController.java
+++ b/src/main/java/com/example/DocLib/controllers/AppointmentController.java
@@ -318,13 +318,25 @@ public class AppointmentController {
         return ResponseEntity.ok(history);
     }
 
-    @GetMapping("/search")
+    @GetMapping("/{id}/search")
     public ResponseEntity<List<AppointmentResponseDto>> searchAppointments(
+            @PathVariable Long id,
             @RequestParam String q,
             @RequestParam(required = false) List<AppointmentStatus> statuses,
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime start,
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime end) {
-        List<AppointmentResponseDto> results = appointmentServicesImp.searchAppointments(q, statuses, start, end);
+        checkAuthenticatedUser(id);
+        Long doctorId = null;
+        Long patientId = null;
+        boolean isDoctor = AuthServices.getCurrentUserRole().stream()
+                .map(org.springframework.security.core.GrantedAuthority::getAuthority)
+                .anyMatch(role -> role.equals("ROLE_DOCTOR"));
+        if (isDoctor) {
+            doctorId = id;
+        } else {
+            patientId = id;
+        }
+        List<AppointmentResponseDto> results = appointmentServicesImp.searchAppointments(q, statuses, start, end, doctorId, patientId);
         return ResponseEntity.ok(results);
     }
 

--- a/src/main/java/com/example/DocLib/repositories/AppointmentRepository.java
+++ b/src/main/java/com/example/DocLib/repositories/AppointmentRepository.java
@@ -66,14 +66,18 @@ public interface AppointmentRepository extends JpaRepository<Appointment,Long> {
     List<Appointment> findByStatus(AppointmentStatus status);
 
     @Query("SELECT a FROM Appointment a WHERE " +
-            "(:query IS NULL OR LOWER(a.doctor.clinicName) LIKE LOWER(CONCAT('%', :query, '%')) " +
-            "OR LOWER(a.patient.name) LIKE LOWER(CONCAT('%', :query, '%'))) " +
+            "(:doctorId IS NULL OR a.doctor.id = :doctorId) " +
+            "AND (:patientId IS NULL OR a.patient.id = :patientId) " +
+            "AND ((:query IS NULL OR LOWER(a.doctor.clinicName) LIKE LOWER(CONCAT('%', :query, '%')) " +
+            "OR LOWER(a.patient.name) LIKE LOWER(CONCAT('%', :query, '%')))) " +
             "AND (:statuses IS NULL OR a.status IN :statuses) " +
             "AND (:startTime IS NULL OR a.startTime >= :startTime) " +
             "AND (:endTime IS NULL OR a.endTime <= :endTime)")
     List<Appointment> searchAppointments(@Param("query") String query,
                                          @Param("statuses") List<AppointmentStatus> statuses,
                                          @Param("startTime") LocalDateTime startTime,
-                                         @Param("endTime") LocalDateTime endTime);
+                                         @Param("endTime") LocalDateTime endTime,
+                                         @Param("doctorId") Long doctorId,
+                                         @Param("patientId") Long patientId);
 
 }

--- a/src/main/java/com/example/DocLib/services/implementation/AppointmentServicesImp.java
+++ b/src/main/java/com/example/DocLib/services/implementation/AppointmentServicesImp.java
@@ -344,9 +344,11 @@ public class AppointmentServicesImp implements AppointmentServices {
     public List<AppointmentResponseDto> searchAppointments(String query,
                                                            List<AppointmentStatus> statuses,
                                                            LocalDateTime startTime,
-                                                           LocalDateTime endTime) {
+                                                           LocalDateTime endTime,
+                                                           Long doctorId,
+                                                           Long patientId) {
         return getResponseAppointmentList(
-                appointmentRepository.searchAppointments(query, statuses, startTime, endTime)
+                appointmentRepository.searchAppointments(query, statuses, startTime, endTime, doctorId, patientId)
         );
     }
 

--- a/src/main/java/com/example/DocLib/services/interfaces/AppointmentServices.java
+++ b/src/main/java/com/example/DocLib/services/interfaces/AppointmentServices.java
@@ -54,7 +54,9 @@ public interface AppointmentServices {
         List<AppointmentResponseDto> searchAppointments(String query,
                                                         List<AppointmentStatus> statuses,
                                                         LocalDateTime startTime,
-                                                        LocalDateTime endTime);
+                                                        LocalDateTime endTime,
+                                                        Long doctorId,
+                                                        Long patientId);
     }
 
 


### PR DESCRIPTION
## Summary
- restrict search endpoint to require user id
- filter search results by role-based id (doctor or patient)
- update repository query and service interfaces

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685acf14f6388331b0a407d7c6f139f7