### PR TITLE
Fix schedule update mapping

### DIFF
--- a/src/main/java/com/example/DocLib/configruation/MapperConfig.java
+++ b/src/main/java/com/example/DocLib/configruation/MapperConfig.java
@@ -23,9 +23,15 @@ public class MapperConfig {
         modelMapper.typeMap(DoctorServiceDto.class, DoctorService.class)
                 .addMappings(mapper -> mapper.skip(DoctorService::setId));
         modelMapper.typeMap(DoctorScheduleDto.class, DoctorSchedule.class)
-                .addMappings(mapper -> mapper.skip(DoctorSchedule::setId));
+                .addMappings(mapper -> {
+                    mapper.skip(DoctorSchedule::setId);
+                    mapper.skip(DoctorSchedule::setDoctor);
+                });
         modelMapper.typeMap(DoctorHolidayScheduleDto.class, DoctorHolidaySchedule.class)
-                .addMappings(mapper -> mapper.skip(DoctorHolidaySchedule::setId));
+                .addMappings(mapper -> {
+                    mapper.skip(DoctorHolidaySchedule::setId);
+                    mapper.skip(DoctorHolidaySchedule::setDoctor);
+                });
 
         return modelMapper;
     }


### PR DESCRIPTION
## Summary
- prevent ModelMapper from overwriting the `doctor` relationship when mapping DoctorScheduleDto and DoctorHolidayScheduleDto

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6867ffb56cd08331a424efc96d54b23e